### PR TITLE
Update mod to 1.21, 1.21.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,8 +3,8 @@ plugins {
 	id 'maven-publish'
 }
 
-sourceCompatibility = JavaVersion.VERSION_17
-targetCompatibility = JavaVersion.VERSION_17
+sourceCompatibility = JavaVersion.VERSION_21
+targetCompatibility = JavaVersion.VERSION_21
 
 archivesBaseName = project.archives_base_name
 version = project.minecraft_version + "-" + project.mod_version
@@ -50,8 +50,8 @@ processResources {
 }
 
 tasks.withType(JavaCompile).configureEach {
-	// Minecraft 1.18 (1.18-pre2) upwards uses Java 17.
-	it.options.release = 17
+	// Minecraft 1.21 upwards uses Java 21.
+	it.options.release = 21
 }
 
 java {

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,13 +2,13 @@
 org.gradle.jvmargs=-Xmx2G
 
 # Fabric Properties
-minecraft_version=1.20.6
-yarn_mappings=1.20.6+build.3
-parchment_mapppings=1.20.6:2024.06.16
-loader_version=0.15.11
+minecraft_version=1.21.1
+yarn_mappings=1.21.1+build.3
+parchment_mapppings=1.21:2024.07.28
+loader_version=0.16.9
 
 #Fabric api
-fabric_version=0.100.4+1.20.6
+fabric_version=0.107.0+1.21.1
 
 # Mod Properties
 mod_version = 1.7.0

--- a/src/main/java/com/aqupd/grizzlybear/Main.java
+++ b/src/main/java/com/aqupd/grizzlybear/Main.java
@@ -31,7 +31,7 @@ public class Main implements ModInitializer {
 
 	public static final EntityType<GrizzlyBearEntity> GRIZZLYBEAR = Registry.register(
 			BuiltInRegistries.ENTITY_TYPE,
-			new ResourceLocation("aqupd", "grizzly_bear"),
+			ResourceLocation.fromNamespaceAndPath("aqupd", "grizzly_bear"),
 			EntityType.Builder.of(GrizzlyBearEntity::new, MobCategory.CREATURE).sized(1.4f, 1.4f).build()
 	);
 
@@ -44,13 +44,13 @@ public class Main implements ModInitializer {
 
 	public static final SpawnEggItem GRIZZLY_BEAR_SPAWN_EGG = new SpawnEggItem(GRIZZLYBEAR, 8545340, 4139806, new Item.Properties().stacksTo(64));
 
-	public static final TagKey<Biome> GRIZZLY_BEAR_SPAWN_BIOMES = TagKey.create(Registries.BIOME, new ResourceLocation("aqupd", "grizzly_bear_spawning_biomes"));
+	public static final TagKey<Biome> GRIZZLY_BEAR_SPAWN_BIOMES = TagKey.create(Registries.BIOME, ResourceLocation.fromNamespaceAndPath("aqupd", "grizzly_bear_spawning_biomes"));
 
 	@Override
 	public void onInitialize() {
 		ServerWorldEvents.LOAD.register((server, world) -> AqDebug.INSTANCE.startDebug(AqConfig.INSTANCE.getBooleanProperty("debug")));
 
-		Registry.register(BuiltInRegistries.ITEM, new ResourceLocation("aqupd", "grizzly_bear_spawn_egg"), GRIZZLY_BEAR_SPAWN_EGG);
+		Registry.register(BuiltInRegistries.ITEM, ResourceLocation.fromNamespaceAndPath("aqupd", "grizzly_bear_spawn_egg"), GRIZZLY_BEAR_SPAWN_EGG);
 		FabricDefaultAttributeRegistry.register(GRIZZLYBEAR, GrizzlyBearEntity.createGrizzlyBearAttributes());
 
 		BiomeModifications.addSpawn(
@@ -64,7 +64,7 @@ public class Main implements ModInitializer {
 	}
 
 	private static SoundEvent register(String id) {
-		SoundEvent soundEvent = SoundEvent.createVariableRangeEvent(new ResourceLocation("aqupd", id));
+		SoundEvent soundEvent = SoundEvent.createVariableRangeEvent(ResourceLocation.fromNamespaceAndPath("aqupd", id));
 		return Registry.register(BuiltInRegistries.SOUND_EVENT, id, soundEvent);
 	}
 }

--- a/src/main/java/com/aqupd/grizzlybear/MainClient.java
+++ b/src/main/java/com/aqupd/grizzlybear/MainClient.java
@@ -13,7 +13,7 @@ import net.minecraft.resources.ResourceLocation;
 @Environment(EnvType.CLIENT)
 public class MainClient implements ClientModInitializer {
 
-    public static final ModelLayerLocation GRIZZLY_BEAR_LAYER = new ModelLayerLocation(new ResourceLocation("aqupd", "grizzly_bear"), "main");
+    public static final ModelLayerLocation GRIZZLY_BEAR_LAYER = new ModelLayerLocation(ResourceLocation.fromNamespaceAndPath("aqupd", "grizzly_bear"), "main");
 
     @Override
     public void onInitializeClient() {

--- a/src/main/java/com/aqupd/grizzlybear/client/renderer/GrizzlyBearEntityRenderer.java
+++ b/src/main/java/com/aqupd/grizzlybear/client/renderer/GrizzlyBearEntityRenderer.java
@@ -13,7 +13,7 @@ import org.jetbrains.annotations.NotNull;
 
 @Environment(EnvType.CLIENT)
 public class GrizzlyBearEntityRenderer extends MobRenderer<GrizzlyBearEntity, GrizzlyBearEntityModel<GrizzlyBearEntity>> {
-    private static final ResourceLocation TEXTURE = new ResourceLocation("aqupd", "textures/entity/grizzly_bear.png");
+    private static final ResourceLocation TEXTURE = ResourceLocation.fromNamespaceAndPath("aqupd", "textures/entity/grizzly_bear.png");
 
     public GrizzlyBearEntityRenderer(EntityRendererProvider.Context context) {
         super(context, new GrizzlyBearEntityModel<>(context.bakeLayer(MainClient.GRIZZLY_BEAR_LAYER)), 0.9F);

--- a/src/main/java/com/aqupd/grizzlybear/entities/GrizzlyBearEntity.java
+++ b/src/main/java/com/aqupd/grizzlybear/entities/GrizzlyBearEntity.java
@@ -36,6 +36,7 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.item.crafting.Ingredient;
+import net.minecraft.world.item.enchantment.EnchantmentHelper;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.ServerLevelAccessor;
 import net.minecraft.world.level.block.state.BlockState;
@@ -212,13 +213,13 @@ public class GrizzlyBearEntity extends Animal implements NeutralMob {
         }
     }
 
-    public boolean doHurtTarget(Entity target) {
-        boolean bl = target.hurt(this.damageSources().mobAttack(this), (float)((int)this.getAttributeValue(Attributes.ATTACK_DAMAGE)));
-        if (bl) {
-            this.doEnchantDamageEffects(this, target);
-        }
-        return bl;
-    }
+//    public boolean doHurtTarget(Entity target) {
+//        boolean bl = target.hurt(this.damageSources().mobAttack(this), (float)((int)this.getAttributeValue(Attributes.ATTACK_DAMAGE)));
+//        if (bl) {
+//            this.doEnchantDamageEffects(this, target);
+//        }
+//        return bl;
+//    }
 
     public boolean isStanding() {
         return this.entityData.get(WARNING);

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -30,9 +30,9 @@
   "mixins": [],
   "accessWidener" : "aqupdgrizzly.accesswidener",
   "depends": {
-    "fabricloader": ">=0.14.21",
-    "minecraft": "~1.20",
-    "java": ">=17",
-    "fabric-api": ">=0.83.0+1.20"
+    "fabricloader": ">=0.16.9",
+    "minecraft": "~1.21",
+    "java": ">=21",
+    "fabric-api": ">=0.102.0+1.21"
   }
 }


### PR DESCRIPTION
Hello! These changes update the mod to be compatible with 1.21 & 1.21.1.

**Changes:**
- In `gradle.properties`
  - Changed `minecraft_version` to `1.21.1`
  - Changed `yarn_mappings` to `1.21.1+build.3`
  - Changed `parchment_mapppings` to `1.21:2024.07.28`
  - Changed `loader_version` to `0.16.9`
  - Changed `fabric_version` to `0.107.0+1.21.1`
- In `fabric.mod.json`
  - Changed `fabricloader` to `>=0.16.9`
  - Changed `minecraft` to `~1.21` (This can probably be changed further because the mod is not compatible with anything above 1.21.1)
  - Changed `java` to `>=21`
  - Changed `fabric-api` to `>=0.102.0+1.21`
- Updated a few pieces of code to be compatible with the new mappings.
  - Note: I commented out `GrizzlyBearEntity::doHurtTarget` because I could not find a suitable replacement for `doEnchantDamageEffects`. 